### PR TITLE
factory

### DIFF
--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -1163,11 +1163,18 @@ blib : $(BLIB)
 # Command to generate build ID.  Must be unique for each $(BIN)/%.tmp,
 # even within the same build run.
 #
-BUILD_ID_CMD	:= perl -e 'printf "0x%08x", int ( rand ( 0xffffffff ) );'
+# NB: In the case of the SUSE qemu-ipxe package we want reproducible
+# builds, so we just use the TGT_ROM_NAME variable, which is already
+# a unique (in the context of the files we generate) hex value suitable
+# for specifying the build_id. We no longer define a BUILD_ID_CMD, as
+# we need to use the TGT_ROM_NAME variable directly in the link command
 
 # Build timestamp
 #
-BUILD_TIMESTAMP := $(shell date +%s)
+# NB: In the case of the SUSE qemu-ipxe package we want reproducible
+# builds, so we use a pre-determined timestamp, rather than the current
+# timestamp
+BUILD_TIMESTAMP := $(PACKAGING_TIMESTAMP)
 
 # Build version
 #
@@ -1187,7 +1194,7 @@ $(BIN)/version.%.o : core/version.c $(MAKEDEPS) $(GIT_INDEX)
 $(BIN)/%.tmp : $(BIN)/version.%.o $(BLIB) $(MAKEDEPS) $(LDSCRIPT)
 	$(QM)$(ECHO) "  [LD] $@"
 	$(Q)$(LD) $(LDFLAGS) -T $(LDSCRIPT) $(TGT_LD_FLAGS) $< $(BLIB) -o $@ \
-		--defsym _build_id=`$(BUILD_ID_CMD)` \
+		--defsym _build_id=`$(PRINTF) "0x%b" "$(TGT_ROM_NAME)"` \
 		--defsym _build_timestamp=$(BUILD_TIMESTAMP) \
 		-Map $(BIN)/$*.tmp.map
 	$(Q)$(OBJDUMP) -ht $@ | $(PERL) $(SORTOBJDUMP) >> $(BIN)/$*.tmp.map

--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -183,6 +183,19 @@ WNAPM_TEST = $(CC) -Wno-address-of-packed-member -x c -c /dev/null \
 WNAPM_FLAGS := $(shell $(WNAPM_TEST) && \
 		 $(ECHO) '-Wno-address-of-packed-member')
 WORKAROUND_CFLAGS += $(WNAPM_FLAGS)
+
+# gcc 12.1 generates false positive warnings.  Inhibit the warnings.
+WNAB_TEST = $(CC) -Wno-array-bounds -x c -c /dev/null \
+		   -o /dev/null >/dev/null 2>&1
+WNAB_FLAGS := $(shell $(WNAB_TEST) && \
+	      $(ECHO) '-Wno-array-bounds')
+WORKAROUND_CFLAGS += $(WNAB_FLAGS)
+
+WNDP_TEST = $(CC) -Wno-dangling-pointer-x c -c /dev/null \
+		  -o /dev/null >/dev/null 2>&1
+WNDP_FLAGS := $(shell $(WNAB_TEST) && \
+	       $(ECHO) '-Wno-dangling-pointer')
+WORKAROUND_CFLAGS += $(WNDP_FLAGS)
 endif
 
 # Some versions of gas choke on division operators, treating them as

--- a/src/drivers/net/ath/ath5k/ath5k_eeprom.c
+++ b/src/drivers/net/ath/ath5k/ath5k_eeprom.c
@@ -416,6 +416,7 @@ ath5k_eeprom_read_turbo_modes(struct ath5k_hw *ah,
 	if (ee->ee_version < AR5K_EEPROM_VERSION_5_0)
 		return 0;
 
+	AR5K_EEPROM_READ(o++, val);
 	switch (mode){
 	case AR5K_EEPROM_MODE_11A:
 		ee->ee_switch_settling_turbo[mode] = (val >> 6) & 0x7f;

--- a/src/include/ipxe/efi/ProcessorBind.h
+++ b/src/include/ipxe/efi/ProcessorBind.h
@@ -10,20 +10,54 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  *  - mcb30
  */
 
-#if __i386__
+#ifdef EFI_HOSTONLY
+
+/*
+ * We cannot rely on the EDK2 ProcessorBind.h headers when compiling a
+ * binary for execution on the build host itself, since the host's CPU
+ * architecture may not even be supported by EDK2.
+ */
+
+/* Define the basic integer types in terms of the host's <stdint.h> */
+#include <stdint.h>
+typedef int8_t INT8;
+typedef int16_t INT16;
+typedef int32_t INT32;
+typedef int64_t INT64;
+typedef uint8_t UINT8;
+typedef long INTN;
+typedef uint16_t UINT16;
+typedef uint32_t UINT32;
+typedef uint64_t UINT64;
+typedef unsigned long UINTN;
+typedef int8_t CHAR8;
+typedef int16_t CHAR16;
+typedef uint8_t BOOLEAN;
+
+/* Define EFIAPI as whatever API the host uses by default */
+#define EFIAPI
+
+/* Define an architecture-neutral MDE_CPU macro to prevent build errors */
+#define MDE_CPU_EBC
+
+#else /* EFI_HOSTONLY */
+
+#ifdef __i386__
 #include <ipxe/efi/Ia32/ProcessorBind.h>
 #endif
 
-#if __x86_64__
+#ifdef __x86_64__
 #include <ipxe/efi/X64/ProcessorBind.h>
 #endif
 
-#if __arm__
+#ifdef __arm__
 #include <ipxe/efi/Arm/ProcessorBind.h>
 #endif
 
-#if __aarch64__
+#ifdef __aarch64__
 #include <ipxe/efi/AArch64/ProcessorBind.h>
 #endif
+
+#endif /* EFI_HOSTONLY */
 
 #endif /* _IPXE_EFI_PROCESSOR_BIND_H */

--- a/src/tests/bigint_test.c
+++ b/src/tests/bigint_test.c
@@ -210,7 +210,7 @@ void bigint_mod_exp_sample ( const bigint_element_t *base0,
 	static const uint8_t addend_raw[] = addend;			\
 	static const uint8_t value_raw[] = value;			\
 	static const uint8_t expected_raw[] = expected;			\
-	uint8_t result_raw[ sizeof ( expected_raw ) ];			\
+	uint8_t result_raw[ sizeof ( expected_raw ) ] = {0};		\
 	unsigned int size =						\
 		bigint_required_size ( sizeof ( value_raw ) );		\
 	bigint_t ( size ) addend_temp;					\

--- a/src/util/elf2efi.c
+++ b/src/util/elf2efi.c
@@ -33,6 +33,8 @@
 #include <fcntl.h>
 #include <elf.h>
 #include <libgen.h>
+
+#define EFI_HOSTONLY
 #include <ipxe/efi/Uefi.h>
 #include <ipxe/efi/IndustryStandard/PeImage.h>
 


### PR DESCRIPTION
- [ath5k] Add missing AR5K_EEPROM_READ in ath5k_eeprom_read_turbo_modes
- [openSUSE] [build] Makefile: fix issues of build reproducibility
- [openSUSE] [test] help compiler out by initializing array
- [openSUSE] [build] Silence GCC 12 spurious warnings
- [efi] Do not rely on ProcessorBind.h when building host binaries
