### PR TITLE
[efi] Do not rely on ProcessorBind.h when building host binaries

### DIFF
--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -419,8 +419,8 @@ CFLAGS		+= -g
 ifeq ($(CCTYPE),gcc)
 CFLAGS		+= -ffreestanding
 CFLAGS		+= -fcommon
-CFLAGS		+= -Wall -W -Wformat-nonliteral
-HOST_CFLAGS	+= -Wall -W -Wformat-nonliteral
+CFLAGS		+= -Wall -W -Wformat-nonliteral -Wno-array-bounds
+HOST_CFLAGS	+= -Wall -W -Wformat-nonliteral -Wno-array-bounds
 endif
 ifeq ($(CCTYPE),icc)
 CFLAGS		+= -fno-builtin

--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -419,8 +419,10 @@ CFLAGS		+= -g
 ifeq ($(CCTYPE),gcc)
 CFLAGS		+= -ffreestanding
 CFLAGS		+= -fcommon
-CFLAGS		+= -Wall -W -Wformat-nonliteral -Wno-array-bounds
-HOST_CFLAGS	+= -Wall -W -Wformat-nonliteral -Wno-array-bounds
+CFLAGS		+= -Wall -W -Wformat-nonliteral
+CFLAGS		+= -Wno-array-bounds -Wno-dangling-pointer
+HOST_CFLAGS	+= -Wall -W -Wformat-nonliteral
+HOST_CFLAGS	+= -Wno-array-bounds -Wno-dangling-pointer
 endif
 ifeq ($(CCTYPE),icc)
 CFLAGS		+= -fno-builtin

--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -1165,11 +1165,18 @@ blib : $(BLIB)
 # Command to generate build ID.  Must be unique for each $(BIN)/%.tmp,
 # even within the same build run.
 #
-BUILD_ID_CMD	:= perl -e 'printf "0x%08x", int ( rand ( 0xffffffff ) );'
+# NB: In the case of the SUSE qemu-ipxe package we want reproducible
+# builds, so we just use the TGT_ROM_NAME variable, which is already
+# a unique (in the context of the files we generate) hex value suitable
+# for specifying the build_id. We no longer define a BUILD_ID_CMD, as
+# we need to use the TGT_ROM_NAME variable directly in the link command
 
 # Build timestamp
 #
-BUILD_TIMESTAMP := $(shell date +%s)
+# NB: In the case of the SUSE qemu-ipxe package we want reproducible
+# builds, so we use a pre-determined timestamp, rather than the current
+# timestamp
+BUILD_TIMESTAMP := $(PACKAGING_TIMESTAMP)
 
 # Build version
 #
@@ -1189,7 +1196,7 @@ $(BIN)/version.%.o : core/version.c $(MAKEDEPS) $(GIT_INDEX)
 $(BIN)/%.tmp : $(BIN)/version.%.o $(BLIB) $(MAKEDEPS) $(LDSCRIPT)
 	$(QM)$(ECHO) "  [LD] $@"
 	$(Q)$(LD) $(LDFLAGS) -T $(LDSCRIPT) $(TGT_LD_FLAGS) $< $(BLIB) -o $@ \
-		--defsym _build_id=`$(BUILD_ID_CMD)` \
+		--defsym _build_id=`$(PRINTF) "0x%b" "$(TGT_ROM_NAME)"` \
 		--defsym _build_timestamp=$(BUILD_TIMESTAMP) \
 		-Map $(BIN)/$*.tmp.map
 	$(Q)$(OBJDUMP) -ht $@ | $(PERL) $(SORTOBJDUMP) >> $(BIN)/$*.tmp.map

--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -183,6 +183,15 @@ WNAPM_TEST = $(CC) -Wno-address-of-packed-member -x c -c /dev/null \
 WNAPM_FLAGS := $(shell $(WNAPM_TEST) && \
 		 $(ECHO) '-Wno-address-of-packed-member')
 WORKAROUND_CFLAGS += $(WNAPM_FLAGS)
+
+# gcc 15 generates warnings for fixed-length character array
+# initializers that lack a terminating NUL.  Inhibit the warnings.
+#
+WNUSI_TEST = $(CC) -Wunterminated-string-initialization -x c -c /dev/null \
+		   -o /dev/null >/dev/null 2>&1
+WNUSI_FLAGS := $(shell $(WNUSI_TEST) && \
+		$(ECHO) '-Wno-unterminated-string-initialization')
+WORKAROUND_CFLAGS += $(WNUSI_FLAGS)
 endif
 
 # Some versions of gas choke on division operators, treating them as

--- a/src/arch/arm32/core/setjmp.S
+++ b/src/arch/arm32/core/setjmp.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", %progbits
 	.text
 	.arm
 

--- a/src/arch/arm32/libgcc/lldivmod.S
+++ b/src/arch/arm32/libgcc/lldivmod.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", %progbits
 	.text
 	.thumb
 

--- a/src/arch/arm32/libgcc/lldivmod.S
+++ b/src/arch/arm32/libgcc/lldivmod.S
@@ -1,7 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", %progbits
-	.text
 	.thumb
 
 /**

--- a/src/arch/arm32/libgcc/llshift.S
+++ b/src/arch/arm32/libgcc/llshift.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", %progbits
 	.text
 	.arm
 

--- a/src/arch/arm32/libgcc/llshift.S
+++ b/src/arch/arm32/libgcc/llshift.S
@@ -1,7 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", %progbits
-	.text
 	.arm
 
 /**

--- a/src/arch/arm64/core/setjmp.S
+++ b/src/arch/arm64/core/setjmp.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", %progbits
 	.text
 
 	/* Must match jmp_buf structure layout */

--- a/src/arch/i386/core/gdbidt.S
+++ b/src/arch/i386/core/gdbidt.S
@@ -9,6 +9,7 @@
  * Interrupt handlers
  ****************************************************************************
  */
+	.section ".note.GNU-stack", "", @progbits
 	.section ".text", "ax", @progbits
 	.code32
 

--- a/src/arch/i386/core/setjmp.S
+++ b/src/arch/i386/core/setjmp.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.code32

--- a/src/arch/i386/core/setjmp.S
+++ b/src/arch/i386/core/setjmp.S
@@ -2,8 +2,8 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", @progbits
 	.text
-	.arch i386
 	.code32
+	.arch i386
 
 	/* Must match jmp_buf structure layout */
 	.struct	0

--- a/src/arch/i386/scripts/linux.lds
+++ b/src/arch/i386/scripts/linux.lds
@@ -86,16 +86,13 @@ SECTIONS {
 	_assert = ASSERT ( ( _weak == _eweak ), ".weak is non-zero length" );
 
 	/*
-	 * Dispose of the comment and note sections to make the link map
-	 * easier to read
+	 * Dispose of unwanted sections to make the link map easier to read
 	 *
 	 */
 
 	/DISCARD/ : {
 		*(.comment)
 		*(.comment.*)
-		*(.note)
-		*(.note.*)
 		*(.rel)
 		*(.rel.*)
 		*(.discard)

--- a/src/arch/i386/tests/gdbstub_test.S
+++ b/src/arch/i386/tests/gdbstub_test.S
@@ -1,3 +1,4 @@
+	.section ".note.GNU-stack", "", @progbits
 	.arch i386
 
 	.section ".data", "aw", @progbits

--- a/src/arch/i386/tests/gdbstub_test.S
+++ b/src/arch/i386/tests/gdbstub_test.S
@@ -1,4 +1,5 @@
 	.section ".note.GNU-stack", "", @progbits
+	.code32
 	.arch i386
 
 	.section ".data", "aw", @progbits

--- a/src/arch/x86/core/patch_cf.S
+++ b/src/arch/x86/core/patch_cf.S
@@ -22,6 +22,7 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.code16

--- a/src/arch/x86/core/patch_cf.S
+++ b/src/arch/x86/core/patch_cf.S
@@ -23,7 +23,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i386
 	.code16
 

--- a/src/arch/x86/core/patch_cf.S
+++ b/src/arch/x86/core/patch_cf.S
@@ -23,8 +23,8 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", @progbits
-	.arch i386
 	.code16
+	.arch i386
 
 /****************************************************************************
  * Set/clear CF on the stack as appropriate, assumes stack is as it should

--- a/src/arch/x86/core/stack.S
+++ b/src/arch/x86/core/stack.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.arch i386
 
 #ifdef __x86_64__

--- a/src/arch/x86/core/stack.S
+++ b/src/arch/x86/core/stack.S
@@ -1,7 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", @progbits
-	.arch i386
 
 #ifdef __x86_64__
 #define STACK_SIZE 8192

--- a/src/arch/x86/core/stack16.S
+++ b/src/arch/x86/core/stack16.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.arch i386
 
 /****************************************************************************

--- a/src/arch/x86/core/stack16.S
+++ b/src/arch/x86/core/stack16.S
@@ -1,7 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", @progbits
-	.arch i386
 
 /****************************************************************************
  * Internal stack

--- a/src/arch/x86/drivers/net/undiisr.S
+++ b/src/arch/x86/drivers/net/undiisr.S
@@ -10,6 +10,7 @@ FILE_LICENCE ( GPL2_OR_LATER )
 #define PIC1_ICR 0x20
 #define PIC2_ICR 0xa0
 	
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.code16

--- a/src/arch/x86/drivers/net/undiisr.S
+++ b/src/arch/x86/drivers/net/undiisr.S
@@ -11,8 +11,8 @@ FILE_LICENCE ( GPL2_OR_LATER )
 #define PIC2_ICR 0xa0
 	
 	.section ".note.GNU-stack", "", @progbits
-	.arch i386
 	.code16
+	.arch i386
 
 	.section ".text16", "ax", @progbits
 	.globl undiisr

--- a/src/arch/x86/drivers/net/undiisr.S
+++ b/src/arch/x86/drivers/net/undiisr.S
@@ -11,7 +11,6 @@ FILE_LICENCE ( GPL2_OR_LATER )
 #define PIC2_ICR 0xa0
 	
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i386
 	.code16
 

--- a/src/arch/x86/include/librm.h
+++ b/src/arch/x86/include/librm.h
@@ -250,8 +250,10 @@ extern void remove_user_from_rm_stack ( userptr_t data, size_t size );
 /* CODE_DEFAULT: restore default .code32/.code64 directive */
 #ifdef __x86_64__
 #define CODE_DEFAULT ".code64"
+#define STACK_DEFAULT "q"
 #else
 #define CODE_DEFAULT ".code32"
+#define STACK_DEFAULT "l"
 #endif
 
 /* LINE_SYMBOL: declare a symbol for the current source code line */
@@ -268,7 +270,7 @@ extern void remove_user_from_rm_stack ( userptr_t data, size_t size );
 
 /* REAL_CODE: declare a fragment of code that executes in real mode */
 #define REAL_CODE( asm_code_str )			\
-	"push $1f\n\t"					\
+	"push" STACK_DEFAULT " $1f\n\t"			\
 	"call real_call\n\t"				\
 	TEXT16_CODE ( "\n1:\n\t"			\
 		      asm_code_str			\
@@ -277,7 +279,7 @@ extern void remove_user_from_rm_stack ( userptr_t data, size_t size );
 
 /* PHYS_CODE: declare a fragment of code that executes in flat physical mode */
 #define PHYS_CODE( asm_code_str )			\
-	"push $1f\n\t"					\
+	"push" STACK_DEFAULT " $1f\n\t"			\
 	"call phys_call\n\t"				\
 	".section \".text.phys\", \"ax\", @progbits\n\t"\
 	"\n" LINE_SYMBOL "\n\t"				\

--- a/src/arch/x86/interface/pcbios/e820mangler.S
+++ b/src/arch/x86/interface/pcbios/e820mangler.S
@@ -23,6 +23,7 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.code16

--- a/src/arch/x86/interface/pcbios/e820mangler.S
+++ b/src/arch/x86/interface/pcbios/e820mangler.S
@@ -24,8 +24,8 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", @progbits
-	.arch i386
 	.code16
+	.arch i386
 
 #define SMAP 0x534d4150
 

--- a/src/arch/x86/interface/pcbios/e820mangler.S
+++ b/src/arch/x86/interface/pcbios/e820mangler.S
@@ -24,7 +24,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i386
 	.code16
 

--- a/src/arch/x86/interface/pxe/pxe_entry.S
+++ b/src/arch/x86/interface/pxe/pxe_entry.S
@@ -26,6 +26,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
+	.section ".note.GNU-stack", "", @progbits
 	.arch i386
 
 /****************************************************************************

--- a/src/arch/x86/interface/pxe/pxe_entry.S
+++ b/src/arch/x86/interface/pxe/pxe_entry.S
@@ -27,6 +27,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #include <librm.h>
 
 	.section ".note.GNU-stack", "", @progbits
+	.code16
 	.arch i386
 
 /****************************************************************************

--- a/src/arch/x86/interface/syslinux/com32_wrapper.S
+++ b/src/arch/x86/interface/syslinux/com32_wrapper.S
@@ -21,6 +21,7 @@ FILE_LICENCE ( GPL2_OR_LATER )
 
 #include "librm.h"
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 
 	.code32

--- a/src/arch/x86/prefix/bootpart.S
+++ b/src/arch/x86/prefix/bootpart.S
@@ -5,6 +5,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define STACK_SEG 	0x0200
 #define STACK_SIZE	0x2000
 	
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.section ".prefix", "awx", @progbits

--- a/src/arch/x86/prefix/bootpart.S
+++ b/src/arch/x86/prefix/bootpart.S
@@ -6,9 +6,9 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define STACK_SIZE	0x2000
 	
 	.section ".note.GNU-stack", "", @progbits
+	.code16
 	.arch i386
 	.section ".prefix", "awx", @progbits
-	.code16
 
 /*
  * Find active partition

--- a/src/arch/x86/prefix/bootpart.S
+++ b/src/arch/x86/prefix/bootpart.S
@@ -6,7 +6,6 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define STACK_SIZE	0x2000
 	
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i386
 	.section ".prefix", "awx", @progbits
 	.code16

--- a/src/arch/x86/prefix/dskprefix.S
+++ b/src/arch/x86/prefix/dskprefix.S
@@ -24,6 +24,7 @@ FILE_LICENCE ( GPL2_ONLY )
 
 .equ	SYSSEG, 0x1000			/* system loaded at SYSSEG<<4 */
 
+	.section ".note.GNU-stack", "", @progbits
 	.org	0
 	.arch i386
 	.text

--- a/src/arch/x86/prefix/dskprefix.S
+++ b/src/arch/x86/prefix/dskprefix.S
@@ -26,9 +26,9 @@ FILE_LICENCE ( GPL2_ONLY )
 
 	.section ".note.GNU-stack", "", @progbits
 	.org	0
+	.code16
 	.arch i386
 	.section ".prefix", "ax", @progbits
-	.code16
 	.globl	_dsk_start
 _dsk_start:
 

--- a/src/arch/x86/prefix/dskprefix.S
+++ b/src/arch/x86/prefix/dskprefix.S
@@ -27,7 +27,6 @@ FILE_LICENCE ( GPL2_ONLY )
 	.section ".note.GNU-stack", "", @progbits
 	.org	0
 	.arch i386
-	.text
 	.section ".prefix", "ax", @progbits
 	.code16
 	.globl	_dsk_start

--- a/src/arch/x86/prefix/exeprefix.S
+++ b/src/arch/x86/prefix/exeprefix.S
@@ -36,6 +36,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define PSP_CMDLINE_LEN 0x80
 #define PSP_CMDLINE_START 0x81
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.org 0

--- a/src/arch/x86/prefix/exeprefix.S
+++ b/src/arch/x86/prefix/exeprefix.S
@@ -37,9 +37,9 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define PSP_CMDLINE_START 0x81
 
 	.section ".note.GNU-stack", "", @progbits
+	.code16
 	.arch i386
 	.org 0
-	.code16
 	.section ".prefix", "awx", @progbits
 
 signature:

--- a/src/arch/x86/prefix/exeprefix.S
+++ b/src/arch/x86/prefix/exeprefix.S
@@ -37,7 +37,6 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define PSP_CMDLINE_START 0x81
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i386
 	.org 0
 	.code16

--- a/src/arch/x86/prefix/hdprefix.S
+++ b/src/arch/x86/prefix/hdprefix.S
@@ -2,6 +2,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.section ".prefix", "awx", @progbits

--- a/src/arch/x86/prefix/hdprefix.S
+++ b/src/arch/x86/prefix/hdprefix.S
@@ -3,9 +3,9 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #include <librm.h>
 
 	.section ".note.GNU-stack", "", @progbits
+	.code16
 	.arch i386
 	.section ".prefix", "awx", @progbits
-	.code16
 	.org 0
 	.globl	_hd_start
 _hd_start:

--- a/src/arch/x86/prefix/hdprefix.S
+++ b/src/arch/x86/prefix/hdprefix.S
@@ -3,7 +3,6 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #include <librm.h>
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i386
 	.section ".prefix", "awx", @progbits
 	.code16

--- a/src/arch/x86/prefix/libprefix.S
+++ b/src/arch/x86/prefix/libprefix.S
@@ -26,6 +26,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
+	.section ".note.GNU-stack", "", @progbits
 	.arch i386
 
 /* Image compression enabled */

--- a/src/arch/x86/prefix/libprefix.S
+++ b/src/arch/x86/prefix/libprefix.S
@@ -27,6 +27,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #include <librm.h>
 
 	.section ".note.GNU-stack", "", @progbits
+	.code16
 	.arch i386
 
 /* Image compression enabled */

--- a/src/arch/x86/prefix/lkrnprefix.S
+++ b/src/arch/x86/prefix/lkrnprefix.S
@@ -4,6 +4,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #define BZI_LOAD_HIGH_ADDR 0x100000
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.code16

--- a/src/arch/x86/prefix/lkrnprefix.S
+++ b/src/arch/x86/prefix/lkrnprefix.S
@@ -5,8 +5,8 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define BZI_LOAD_HIGH_ADDR 0x100000
 
 	.section ".note.GNU-stack", "", @progbits
-	.arch i386
 	.code16
+	.arch i386
 	.section ".prefix", "ax", @progbits
 	.globl	_lkrn_start
 _lkrn_start:

--- a/src/arch/x86/prefix/lkrnprefix.S
+++ b/src/arch/x86/prefix/lkrnprefix.S
@@ -5,7 +5,6 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define BZI_LOAD_HIGH_ADDR 0x100000
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i386
 	.code16
 	.section ".prefix", "ax", @progbits

--- a/src/arch/x86/prefix/mbr.S
+++ b/src/arch/x86/prefix/mbr.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.section ".prefix", "awx", @progbits

--- a/src/arch/x86/prefix/mbr.S
+++ b/src/arch/x86/prefix/mbr.S
@@ -1,7 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i386
 	.section ".prefix", "awx", @progbits
 	.code16

--- a/src/arch/x86/prefix/mbr.S
+++ b/src/arch/x86/prefix/mbr.S
@@ -1,9 +1,9 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", @progbits
+	.code16
 	.arch i386
 	.section ".prefix", "awx", @progbits
-	.code16
 	.org 0
 
 	.globl mbr

--- a/src/arch/x86/prefix/mromprefix.S
+++ b/src/arch/x86/prefix/mromprefix.S
@@ -41,6 +41,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define _pcirom_start _mrom_start
 #include "pciromprefix.S"
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.code16

--- a/src/arch/x86/prefix/mromprefix.S
+++ b/src/arch/x86/prefix/mromprefix.S
@@ -42,7 +42,6 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #include "pciromprefix.S"
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i386
 	.code16
 

--- a/src/arch/x86/prefix/mromprefix.S
+++ b/src/arch/x86/prefix/mromprefix.S
@@ -42,8 +42,8 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #include "pciromprefix.S"
 
 	.section ".note.GNU-stack", "", @progbits
-	.arch i386
 	.code16
+	.arch i386
 
 /* Obtain access to payload by exposing the expansion ROM BAR at the
  * address currently used by a suitably large memory BAR on the same

--- a/src/arch/x86/prefix/nbiprefix.S
+++ b/src/arch/x86/prefix/nbiprefix.S
@@ -2,6 +2,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.code16

--- a/src/arch/x86/prefix/nbiprefix.S
+++ b/src/arch/x86/prefix/nbiprefix.S
@@ -3,7 +3,6 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #include <librm.h>
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i386
 	.code16
 	.section ".prefix", "ax", @progbits

--- a/src/arch/x86/prefix/nbiprefix.S
+++ b/src/arch/x86/prefix/nbiprefix.S
@@ -3,8 +3,8 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #include <librm.h>
 
 	.section ".note.GNU-stack", "", @progbits
-	.arch i386
 	.code16
+	.arch i386
 	.section ".prefix", "ax", @progbits
 	.org 0
 

--- a/src/arch/x86/prefix/nullprefix.S
+++ b/src/arch/x86/prefix/nullprefix.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.org	0
 	.text
 	.arch i386

--- a/src/arch/x86/prefix/nullprefix.S
+++ b/src/arch/x86/prefix/nullprefix.S
@@ -2,7 +2,6 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", @progbits
 	.org	0
-	.text
 	.arch i386
 
 	.section ".prefix", "ax", @progbits

--- a/src/arch/x86/prefix/nullprefix.S
+++ b/src/arch/x86/prefix/nullprefix.S
@@ -2,10 +2,10 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", @progbits
 	.org	0
+	.code16
 	.arch i386
 
 	.section ".prefix", "ax", @progbits
-	.code16
 _prefix:
 
 	.section ".text16", "ax", @progbits

--- a/src/arch/x86/prefix/pxeprefix.S
+++ b/src/arch/x86/prefix/pxeprefix.S
@@ -11,6 +11,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #define PXE_HACK_EB54			0x0001
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.org 0

--- a/src/arch/x86/prefix/pxeprefix.S
+++ b/src/arch/x86/prefix/pxeprefix.S
@@ -12,7 +12,6 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define PXE_HACK_EB54			0x0001
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i386
 	.org 0
 	.code16

--- a/src/arch/x86/prefix/pxeprefix.S
+++ b/src/arch/x86/prefix/pxeprefix.S
@@ -12,9 +12,9 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define PXE_HACK_EB54			0x0001
 
 	.section ".note.GNU-stack", "", @progbits
+	.code16
 	.arch i386
 	.org 0
-	.code16
 
 #include <librm.h>
 #include <undi.h>

--- a/src/arch/x86/prefix/rawprefix.S
+++ b/src/arch/x86/prefix/rawprefix.S
@@ -1,0 +1,53 @@
+/*
+ * Raw binary prefix
+ *
+ * Assumes that entire image is already loaded as a contiguous block
+ * on a paragraph boundary and entered in real mode.
+ *
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
+
+	.text
+	.arch i386
+	.org 0
+	.code16
+
+#include <librm.h>
+
+	.section ".prefix", "ax", @progbits
+	.globl	_raw_start
+_raw_start:
+
+	/* Adjust %cs so that %cs:0000 is the start of the image */
+	movw	%cs, %ax
+	call	1f
+1:	popw	%bx
+	subw	$1b, %bx
+	shrw	$4, %bx
+	addw	%bx, %ax
+	pushw	%ax
+	pushw	$2f
+	lret
+2:
+	/* Install iPXE */
+	call	install
+
+	/* Set up real-mode stack */
+	movw	%bx, %ss
+	movw	$_estack16, %sp
+
+	/* Jump to .text16 segment */
+	pushw	%ax
+	pushw	$1f
+	lret
+	.section ".text16", "awx", @progbits
+1:
+	/* Run iPXE */
+	virtcall main
+
+	/* Uninstall iPXE */
+	call	uninstall
+
+	/* Boot next device */
+	int $0x18

--- a/src/arch/x86/prefix/rawprefix.S
+++ b/src/arch/x86/prefix/rawprefix.S
@@ -8,6 +8,7 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.org 0

--- a/src/arch/x86/prefix/rawprefix.S
+++ b/src/arch/x86/prefix/rawprefix.S
@@ -9,9 +9,9 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", @progbits
+	.code16
 	.arch i386
 	.org 0
-	.code16
 
 #include <librm.h>
 

--- a/src/arch/x86/prefix/rawprefix.S
+++ b/src/arch/x86/prefix/rawprefix.S
@@ -9,7 +9,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i386
 	.org 0
 	.code16

--- a/src/arch/x86/prefix/romprefix.S
+++ b/src/arch/x86/prefix/romprefix.S
@@ -54,6 +54,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define BUSTYPE "PCIR"
 #endif
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.code16
 	.arch i386

--- a/src/arch/x86/prefix/romprefix.S
+++ b/src/arch/x86/prefix/romprefix.S
@@ -55,7 +55,6 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #endif
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.code16
 	.arch i386
 	.section ".prefix", "ax", @progbits

--- a/src/arch/x86/prefix/undiloader.S
+++ b/src/arch/x86/prefix/undiloader.S
@@ -2,6 +2,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <librm.h>
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.code16
 	.arch i386

--- a/src/arch/x86/prefix/undiloader.S
+++ b/src/arch/x86/prefix/undiloader.S
@@ -3,7 +3,6 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #include <librm.h>
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.code16
 	.arch i386
 	.section ".prefix", "ax", @progbits

--- a/src/arch/x86/prefix/unlzma.S
+++ b/src/arch/x86/prefix/unlzma.S
@@ -43,6 +43,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  ****************************************************************************
  */
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i486
 	.section ".prefix.lib", "ax", @progbits

--- a/src/arch/x86/prefix/unlzma.S
+++ b/src/arch/x86/prefix/unlzma.S
@@ -44,7 +44,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  */
 
 	.text
-	.arch i586
+	.arch i486
 	.section ".prefix.lib", "ax", @progbits
 
 #ifdef CODE16

--- a/src/arch/x86/prefix/unlzma.S
+++ b/src/arch/x86/prefix/unlzma.S
@@ -44,6 +44,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  */
 
 	.section ".note.GNU-stack", "", @progbits
+	.code32
 	.arch i486
 	.section ".prefix.lib", "ax", @progbits
 

--- a/src/arch/x86/prefix/unlzma.S
+++ b/src/arch/x86/prefix/unlzma.S
@@ -44,7 +44,6 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  */
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i486
 	.section ".prefix.lib", "ax", @progbits
 

--- a/src/arch/x86/prefix/usbdisk.S
+++ b/src/arch/x86/prefix/usbdisk.S
@@ -2,6 +2,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 #include <config/console.h>
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.section ".prefix", "awx", @progbits

--- a/src/arch/x86/prefix/usbdisk.S
+++ b/src/arch/x86/prefix/usbdisk.S
@@ -3,9 +3,9 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #include <config/console.h>
 
 	.section ".note.GNU-stack", "", @progbits
+	.code16
 	.arch i386
 	.section ".prefix", "awx", @progbits
-	.code16
 	.org 0
 
 #include "mbr.S"

--- a/src/arch/x86/prefix/usbdisk.S
+++ b/src/arch/x86/prefix/usbdisk.S
@@ -3,7 +3,6 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #include <config/console.h>
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i386
 	.section ".prefix", "awx", @progbits
 	.code16

--- a/src/arch/x86/transitions/liba20.S
+++ b/src/arch/x86/transitions/liba20.S
@@ -24,6 +24,7 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.arch i386
 
 /****************************************************************************

--- a/src/arch/x86/transitions/liba20.S
+++ b/src/arch/x86/transitions/liba20.S
@@ -25,6 +25,7 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
 	.section ".note.GNU-stack", "", @progbits
+	.code16
 	.arch i386
 
 /****************************************************************************

--- a/src/arch/x86/transitions/libkir.S
+++ b/src/arch/x86/transitions/libkir.S
@@ -31,6 +31,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 /* Breakpoint for when debugging under bochs */
 #define BOCHSBP xchgw %bx, %bx
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.arch i386
 	.section ".text16", "awx", @progbits

--- a/src/arch/x86/transitions/libkir.S
+++ b/src/arch/x86/transitions/libkir.S
@@ -32,9 +32,9 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define BOCHSBP xchgw %bx, %bx
 
 	.section ".note.GNU-stack", "", @progbits
+	.code16
 	.arch i386
 	.section ".text16", "awx", @progbits
-	.code16
 	
 /****************************************************************************
  * init_libkir (real-mode or 16:xx protected-mode far call)

--- a/src/arch/x86/transitions/libkir.S
+++ b/src/arch/x86/transitions/libkir.S
@@ -32,7 +32,6 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define BOCHSBP xchgw %bx, %bx
 
 	.section ".note.GNU-stack", "", @progbits
-	.text
 	.arch i386
 	.section ".text16", "awx", @progbits
 	.code16

--- a/src/arch/x86/transitions/librm.S
+++ b/src/arch/x86/transitions/librm.S
@@ -83,6 +83,8 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 #define if64 if 0
 #endif
 
+	.section ".note.GNU-stack", "", @progbits
+
 /****************************************************************************
  * Global descriptor table
  *

--- a/src/arch/x86_64/core/gdbidt.S
+++ b/src/arch/x86_64/core/gdbidt.S
@@ -38,6 +38,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #define SIGFPE 8
 #define SIGSTKFLT 16
 
+	.section ".note.GNU-stack", "", @progbits
 	.section ".text.gdbmach_interrupt", "ax", @progbits
 	.code64
 

--- a/src/arch/x86_64/core/setjmp.S
+++ b/src/arch/x86_64/core/setjmp.S
@@ -1,5 +1,6 @@
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 
+	.section ".note.GNU-stack", "", @progbits
 	.text
 	.code64
 

--- a/src/drivers/infiniband/mlx_utils/src/public/mlx_pci_gw.c
+++ b/src/drivers/infiniband/mlx_utils/src/public/mlx_pci_gw.c
@@ -32,7 +32,7 @@ mlx_status
 mlx_pci_gw_check_capability_id(
 							IN mlx_utils *utils,
 							IN mlx_uint8 cap_pointer,
-							OUT mlx_boolean *bool
+							OUT mlx_boolean *result
 							)
 {
 	mlx_status 		status = MLX_SUCCESS;
@@ -41,7 +41,7 @@ mlx_pci_gw_check_capability_id(
 	status = mlx_pci_read(utils, MlxPciWidthUint8, offset,
 				1, &id);
 	MLX_CHECK_STATUS(utils, status, read_err,"failed to read capability id");
-	*bool = ( id == PCI_GW_CAPABILITY_ID );
+	*result = ( id == PCI_GW_CAPABILITY_ID );
 read_err:
 	return status;
 }

--- a/src/drivers/net/3c595.c
+++ b/src/drivers/net/3c595.c
@@ -443,7 +443,7 @@ vxsetlink(void)
     GO_WINDOW(1); 
 }
 
-static void t595_disable ( struct nic *nic ) {
+static void t595_disable ( struct nic *nic, void *hwdev __unused ) {
 
 	t595_reset(nic);
 

--- a/src/drivers/net/3c595.c
+++ b/src/drivers/net/3c595.c
@@ -342,8 +342,7 @@ eeprom_rdy()
  * before
  */
 static int
-get_e(offset)
-int offset;
+get_e(int offset)
 {
 	if (!eeprom_rdy())
 		return (0xffff);

--- a/src/drivers/net/amd8111e.c
+++ b/src/drivers/net/amd8111e.c
@@ -609,7 +609,7 @@ static int amd8111e_poll(struct nic *nic, int retrieve)
 	return pkt_ok;
 }
 
-static void amd8111e_disable(struct nic *nic)
+static void amd8111e_disable(struct nic *nic, void *hwdev __unused)
 {
 	struct amd8111e_priv *lp = nic->priv_data;
 

--- a/src/drivers/net/ath/ath5k/ath5k_eeprom.c
+++ b/src/drivers/net/ath/ath5k/ath5k_eeprom.c
@@ -416,6 +416,7 @@ ath5k_eeprom_read_turbo_modes(struct ath5k_hw *ah,
 	if (ee->ee_version < AR5K_EEPROM_VERSION_5_0)
 		return 0;
 
+	AR5K_EEPROM_READ(o++, val);
 	switch (mode){
 	case AR5K_EEPROM_MODE_11A:
 		ee->ee_switch_settling_turbo[mode] = (val >> 6) & 0x7f;

--- a/src/drivers/net/bnx2.c
+++ b/src/drivers/net/bnx2.c
@@ -2671,6 +2671,12 @@ err_out_disable:
 	return 0;
 }
 
+static void
+bnx2_remove(struct nic *nic, void *hwdev __unused)
+{
+	bnx2_disable(nic);
+}
+
 static struct pci_device_id bnx2_nics[] = {
 	PCI_ROM(0x14e4, 0x164a, "bnx2-5706",        "Broadcom NetXtreme II BCM5706", 0),
 	PCI_ROM(0x14e4, 0x164c, "bnx2-5708",        "Broadcom NetXtreme II BCM5708", 0),
@@ -2680,7 +2686,7 @@ static struct pci_device_id bnx2_nics[] = {
 
 PCI_DRIVER ( bnx2_driver, bnx2_nics, PCI_NO_CLASS );
 
-DRIVER ( "BNX2", nic_driver, pci_driver, bnx2_driver, bnx2_probe, bnx2_disable );
+DRIVER ( "BNX2", nic_driver, pci_driver, bnx2_driver, bnx2_probe, bnx2_remove );
 
 /*
 static struct pci_driver bnx2_driver __pci_driver = {

--- a/src/drivers/net/davicom.c
+++ b/src/drivers/net/davicom.c
@@ -159,7 +159,7 @@ static void davicom_reset(struct nic *nic);
 static void davicom_transmit(struct nic *nic, const char *d, unsigned int t,
 			   unsigned int s, const char *p);
 static int davicom_poll(struct nic *nic, int retrieve);
-static void davicom_disable(struct nic *nic);
+static void davicom_disable(struct nic *nic, void *hwdev);
 static void davicom_wait(unsigned int nticks);
 static int phy_read(int);
 static void phy_write(int, u16);
@@ -601,7 +601,7 @@ static int davicom_poll(struct nic *nic, int retrieve)
 /*********************************************************************/
 /* eth_disable - Disable the interface                               */
 /*********************************************************************/
-static void davicom_disable ( struct nic *nic ) {
+static void davicom_disable ( struct nic *nic, void *hwdev __unused ) {
 
   whereami("davicom_disable\n");
 

--- a/src/drivers/net/depca.c
+++ b/src/drivers/net/depca.c
@@ -644,7 +644,7 @@ static void depca_transmit(
 /**************************************************************************
 DISABLE - Turn off ethernet interface
 ***************************************************************************/
-static void depca_disable ( struct nic *nic ) {
+static void depca_disable ( struct nic *nic, void *hwdev __unused ) {
 	depca_reset(nic);
 
 	STOP_DEPCA(nic->ioaddr);

--- a/src/drivers/net/dmfe.c
+++ b/src/drivers/net/dmfe.c
@@ -435,7 +435,7 @@ static void dmfe_transmit(struct nic *nic,
 /**************************************************************************
 DISABLE - Turn off ethernet interface
 ***************************************************************************/
-static void dmfe_disable ( struct nic *nic __unused ) {
+static void dmfe_disable ( struct nic *nic __unused, void *hwdev __unused ) {
 	/* Reset & stop DM910X board */
 	outl(DM910X_RESET, BASE + DCR0);
 	udelay(5);

--- a/src/drivers/net/epic100.c
+++ b/src/drivers/net/epic100.c
@@ -51,7 +51,7 @@ struct epic_tx_desc {
 
 static void	epic100_open(void);
 static void	epic100_init_ring(void);
-static void	epic100_disable(struct nic *nic);
+static void	epic100_disable(struct nic *nic, void *hwdev);
 static int	epic100_poll(struct nic *nic, int retrieve);
 static void	epic100_transmit(struct nic *nic, const char *destaddr,
 				 unsigned int type, unsigned int len, const char *data);
@@ -419,7 +419,7 @@ epic100_poll(struct nic *nic, int retrieve)
 }
 
 
-static void epic100_disable ( struct nic *nic __unused ) {
+static void epic100_disable ( struct nic *nic __unused, void *hwdev __unused ) {
 	/* Soft reset the chip. */
 	outl(GC_SOFT_RESET, genctl);
 }

--- a/src/drivers/net/igbvf/igbvf_osdep.h
+++ b/src/drivers/net/igbvf/igbvf_osdep.h
@@ -35,8 +35,9 @@ FILE_LICENCE ( GPL2_ONLY );
 #ifndef _IGBVF_OSDEP_H_
 #define _IGBVF_OSDEP_H_
 
+#include <stdbool.h>
+
 #define u8         unsigned char
-#define bool       boolean_t
 #define dma_addr_t unsigned long
 #define __le16     uint16_t
 #define __le32     uint32_t
@@ -51,10 +52,6 @@ FILE_LICENCE ( GPL2_ONLY );
 #define ETH_FCS_LEN 4
 
 typedef int spinlock_t;
-typedef enum {
-    false = 0,
-    true = 1
-} boolean_t;
 
 #define usec_delay(x) udelay(x)
 #define msec_delay(x) mdelay(x)

--- a/src/drivers/net/ns8390.c
+++ b/src/drivers/net/ns8390.c
@@ -597,7 +597,7 @@ static int ns8390_poll(struct nic *nic, int retrieve)
 /**************************************************************************
 NS8390_DISABLE - Turn off adapter
 **************************************************************************/
-static void ns8390_disable ( struct nic *nic ) {
+static void ns8390_disable ( struct nic *nic, void *hwdev __unused ) {
 	ns8390_reset(nic);
 }
 

--- a/src/drivers/net/prism2_pci.c
+++ b/src/drivers/net/prism2_pci.c
@@ -44,7 +44,7 @@ static int prism2_pci_probe ( struct nic *nic, struct pci_device *pci ) {
   return prism2_probe ( nic, hw );
 }
 
-static void prism2_pci_disable ( struct nic *nic ) {
+static void prism2_pci_disable ( struct nic *nic, void *hwdev __unused ) {
   prism2_disable ( nic );
 }
 

--- a/src/drivers/net/prism2_plx.c
+++ b/src/drivers/net/prism2_plx.c
@@ -99,7 +99,7 @@ static int prism2_plx_probe ( struct nic *nic, struct pci_device *pci ) {
   return prism2_probe ( nic, hw );
 }
 
-static void prism2_plx_disable ( struct nic *nic ) {
+static void prism2_plx_disable ( struct nic *nic, void *hwdev __unused ) {
   prism2_disable ( nic );
 }
 

--- a/src/drivers/net/sis900.c
+++ b/src/drivers/net/sis900.c
@@ -164,7 +164,7 @@ static void sis900_transmit(struct nic *nic, const char *d,
                             unsigned int t, unsigned int s, const char *p);
 static int  sis900_poll(struct nic *nic, int retrieve);
 
-static void sis900_disable(struct nic *nic);
+static void sis900_disable(struct nic *nic, void *hwdev);
 
 static void sis900_irq(struct nic *nic, irq_action_t action);
 
@@ -1238,7 +1238,7 @@ sis900_poll(struct nic *nic, int retrieve)
  */
 
 static void
-sis900_disable ( struct nic *nic ) {
+sis900_disable ( struct nic *nic, void *hwdev __unused ) {
 
     sis900_init(nic);
 

--- a/src/drivers/net/sundance.c
+++ b/src/drivers/net/sundance.c
@@ -536,7 +536,7 @@ static void sundance_transmit(struct nic *nic, const char *d,	/* Destination */
 /**************************************************************************
 DISABLE - Turn off ethernet interface
 ***************************************************************************/
-static void sundance_disable ( struct nic *nic __unused ) {
+static void sundance_disable ( struct nic *nic __unused, void *hwdev __unused) {
 	/* put the card in its initial state */
 	/* This function serves 3 purposes.
 	 * This disables DMA and interrupts so we don't receive

--- a/src/drivers/net/tlan.c
+++ b/src/drivers/net/tlan.c
@@ -717,7 +717,7 @@ static void tlan_transmit(struct nic *nic, const char *d,	/* Destination */
 /**************************************************************************
 DISABLE - Turn off ethernet interface
 ***************************************************************************/
-static void tlan_disable ( struct nic *nic __unused ) {
+static void tlan_disable ( struct nic *nic __unused, void *hwdev __unused ) {
 	/* put the card in its initial state */
 	/* This function serves 3 purposes.
 	 * This disables DMA and interrupts so we don't receive

--- a/src/drivers/net/tulip.c
+++ b/src/drivers/net/tulip.c
@@ -494,7 +494,7 @@ static void tulip_reset(struct nic *nic);
 static void tulip_transmit(struct nic *nic, const char *d, unsigned int t,
                            unsigned int s, const char *p);
 static int tulip_poll(struct nic *nic, int retrieve);
-static void tulip_disable(struct nic *nic);
+static void tulip_disable(struct nic *nic, void *hwdev);
 static void nway_start(struct nic *nic);
 static void pnic_do_nway(struct nic *nic);
 static void select_media(struct nic *nic, int startup);
@@ -1128,7 +1128,7 @@ static int tulip_poll(struct nic *nic, int retrieve)
 /*********************************************************************/
 /* eth_disable - Disable the interface                               */
 /*********************************************************************/
-static void tulip_disable ( struct nic *nic ) {
+static void tulip_disable ( struct nic *nic, void *hwdev __unused ) {
 
     whereami("tulip_disable\n");
 

--- a/src/drivers/net/w89c840.c
+++ b/src/drivers/net/w89c840.c
@@ -579,7 +579,7 @@ static void w89c840_transmit(
 /**************************************************************************
 w89c840_disable - Turn off ethernet interface
 ***************************************************************************/
-static void w89c840_disable ( struct nic *nic ) {
+static void w89c840_disable ( struct nic *nic, void *hwdev __unused ) {
 
     w89c840_reset(nic);
 

--- a/src/include/ipxe/efi/ProcessorBind.h
+++ b/src/include/ipxe/efi/ProcessorBind.h
@@ -10,20 +10,54 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  *  - mcb30
  */
 
-#if __i386__
+#ifdef EFI_HOSTONLY
+
+/*
+ * We cannot rely on the EDK2 ProcessorBind.h headers when compiling a
+ * binary for execution on the build host itself, since the host's CPU
+ * architecture may not even be supported by EDK2.
+ */
+
+/* Define the basic integer types in terms of the host's <stdint.h> */
+#include <stdint.h>
+typedef int8_t INT8;
+typedef int16_t INT16;
+typedef int32_t INT32;
+typedef int64_t INT64;
+typedef uint8_t UINT8;
+typedef long INTN;
+typedef uint16_t UINT16;
+typedef uint32_t UINT32;
+typedef uint64_t UINT64;
+typedef unsigned long UINTN;
+typedef int8_t CHAR8;
+typedef int16_t CHAR16;
+typedef uint8_t BOOLEAN;
+
+/* Define EFIAPI as whatever API the host uses by default */
+#define EFIAPI
+
+/* Define an architecture-neutral MDE_CPU macro to prevent build errors */
+#define MDE_CPU_EBC
+
+#else /* EFI_HOSTONLY */
+
+#ifdef __i386__
 #include <ipxe/efi/Ia32/ProcessorBind.h>
 #endif
 
-#if __x86_64__
+#ifdef __x86_64__
 #include <ipxe/efi/X64/ProcessorBind.h>
 #endif
 
-#if __arm__
+#ifdef __arm__
 #include <ipxe/efi/Arm/ProcessorBind.h>
 #endif
 
-#if __aarch64__
+#ifdef __aarch64__
 #include <ipxe/efi/AArch64/ProcessorBind.h>
 #endif
+
+#endif /* EFI_HOSTONLY */
 
 #endif /* _IPXE_EFI_PROCESSOR_BIND_H */

--- a/src/include/ipxe/vlan.h
+++ b/src/include/ipxe/vlan.h
@@ -61,7 +61,19 @@ struct vlan_header {
  */
 #define VLAN_PRIORITY_IS_VALID( priority ) ( (priority) <= 7 )
 
-extern unsigned int vlan_tag ( struct net_device *netdev );
+extern unsigned int vlan_tci ( struct net_device *netdev );
+
+/**
+ * Get the VLAN tag
+ *
+ * @v netdev		Network device
+ * @ret tag		VLAN tag, or 0 if device is not a VLAN device
+ */
+static inline __attribute__ (( always_inline )) unsigned int
+vlan_tag ( struct net_device *netdev ) {
+	return VLAN_TAG ( vlan_tci ( netdev ) );
+}
+
 extern int vlan_can_be_trunk ( struct net_device *trunk );
 extern int vlan_create ( struct net_device *trunk, unsigned int tag,
 			 unsigned int priority );

--- a/src/include/ipxe/xenver.h
+++ b/src/include/ipxe/xenver.h
@@ -1,5 +1,5 @@
 #ifndef _IPXE_XENVER_H
-#define _IPXE_VENVER_H
+#define _IPXE_XENVER_H
 
 /** @file
  *

--- a/src/include/nic.h
+++ b/src/include/nic.h
@@ -217,8 +217,7 @@ static inline void * legacy_isa_get_drvdata ( void *hwdev ) {
 	}								  \
 	static inline void						  \
 	_name ## _disable ( struct nic *nic, void *hwdev ) {		  \
-		void ( * _unsafe_disable ) () = _disable;		  \
-		_unsafe_disable ( nic, hwdev );				  \
+		_disable ( nic, hwdev );				  \
 	}								  \
 	static inline int						  \
 	_name ## _pci_legacy_probe ( struct pci_device *pci ) {		  \

--- a/src/interface/efi/efi_hii.c
+++ b/src/interface/efi/efi_hii.c
@@ -147,13 +147,13 @@ void efi_ifr_end_op ( struct efi_ifr_builder *ifr ) {
  */
 void efi_ifr_false_op ( struct efi_ifr_builder *ifr ) {
 	size_t dispaddr = ifr->ops_len;
-	EFI_IFR_FALSE *false;
+	EFI_IFR_FALSE *op;
 
 	/* Add opcode */
-	false = efi_ifr_op ( ifr, EFI_IFR_FALSE_OP, sizeof ( *false ) );
+	op = efi_ifr_op ( ifr, EFI_IFR_FALSE_OP, sizeof ( *op ) );
 
 	DBGC ( ifr, "IFR %p false\n", ifr );
-	DBGC2_HDA ( ifr, dispaddr, false, sizeof ( *false ) );
+	DBGC2_HDA ( ifr, dispaddr, op, sizeof ( *op ) );
 }
 
 /**
@@ -462,13 +462,13 @@ void efi_ifr_text_op ( struct efi_ifr_builder *ifr, unsigned int prompt_id,
  */
 void efi_ifr_true_op ( struct efi_ifr_builder *ifr ) {
 	size_t dispaddr = ifr->ops_len;
-	EFI_IFR_TRUE *true;
+	EFI_IFR_TRUE *op;
 
 	/* Add opcode */
-	true = efi_ifr_op ( ifr, EFI_IFR_TRUE_OP, sizeof ( *true ) );
+	op = efi_ifr_op ( ifr, EFI_IFR_TRUE_OP, sizeof ( *op ) );
 
 	DBGC ( ifr, "IFR %p true\n", ifr );
-	DBGC2_HDA ( ifr, dispaddr, true, sizeof ( *true ) );
+	DBGC2_HDA ( ifr, dispaddr, op, sizeof ( *op ) );
 }
 
 /**

--- a/src/net/netdevice.c
+++ b/src/net/netdevice.c
@@ -1116,12 +1116,12 @@ static void net_step ( struct process *process __unused ) {
 }
 
 /**
- * Get the VLAN tag (when VLAN support is not present)
+ * Get the VLAN tag control information (when VLAN support is not present)
  *
  * @v netdev		Network device
  * @ret tag		0, indicating that device is not a VLAN device
  */
-__weak unsigned int vlan_tag ( struct net_device *netdev __unused ) {
+__weak unsigned int vlan_tci ( struct net_device *netdev __unused ) {
 	return 0;
 }
 

--- a/src/net/vlan.c
+++ b/src/net/vlan.c
@@ -288,17 +288,17 @@ struct net_protocol vlan_protocol __net_protocol = {
 };
 
 /**
- * Get the VLAN tag
+ * Get the VLAN tag control information
  *
  * @v netdev		Network device
- * @ret tag		VLAN tag, or 0 if device is not a VLAN device
+ * @ret tci		VLAN tag control information, or 0 if not a VLAN device
  */
-unsigned int vlan_tag ( struct net_device *netdev ) {
+unsigned int vlan_tci ( struct net_device *netdev ) {
 	struct vlan_device *vlan;
 
 	if ( netdev->op == &vlan_operations ) {
 		vlan = netdev->priv;
-		return vlan->tag;
+		return ( VLAN_TCI ( vlan->tag, vlan->priority ) );
 	} else {
 		return 0;
 	}

--- a/src/tests/bigint_test.c
+++ b/src/tests/bigint_test.c
@@ -210,7 +210,7 @@ void bigint_mod_exp_sample ( const bigint_element_t *base0,
 	static const uint8_t addend_raw[] = addend;			\
 	static const uint8_t value_raw[] = value;			\
 	static const uint8_t expected_raw[] = expected;			\
-	uint8_t result_raw[ sizeof ( expected_raw ) ];			\
+	uint8_t result_raw[ sizeof ( expected_raw ) ] = {0};		\
 	unsigned int size =						\
 		bigint_required_size ( sizeof ( value_raw ) );		\
 	bigint_t ( size ) addend_temp;					\

--- a/src/util/elf2efi.c
+++ b/src/util/elf2efi.c
@@ -33,6 +33,8 @@
 #include <fcntl.h>
 #include <elf.h>
 #include <libgen.h>
+
+#define EFI_HOSTONLY
 #include <ipxe/efi/Uefi.h>
 #include <ipxe/efi/IndustryStandard/PeImage.h>
 


### PR DESCRIPTION
We cannot rely on the EDK2 ProcessorBind.h headers when compiling a
binary for execution on the build host itself (e.g. elf2efi), since
the host's CPU architecture may not even be supported by EDK2.

Fix by skipping ProcessorBind.h when building a host binary, and
defining the bare minimum required to allow other EDK2 headers to
compile cleanly.

Reported-by: Michal Suchánek <msuchanek@suse.de>
Signed-off-by: Michael Brown <mcb30@ipxe.org>
(cherry picked from commit a99e435c8e24887ce80c322029ba23103e00d1c2)
