### PR TITLE
[efi] Do not rely on ProcessorBind.h when building host binaries

### DIFF
--- a/src/Makefile.housekeeping
+++ b/src/Makefile.housekeeping
@@ -183,6 +183,15 @@ WNAPM_TEST = $(CC) -Wno-address-of-packed-member -x c -c /dev/null \
 WNAPM_FLAGS := $(shell $(WNAPM_TEST) && \
 		 $(ECHO) '-Wno-address-of-packed-member')
 WORKAROUND_CFLAGS += $(WNAPM_FLAGS)
+
+# gcc 15 generates warnings for fixed-length character array
+# initializers that lack a terminating NUL.  Inhibit the warnings.
+#
+WNUSI_TEST = $(CC) -Wunterminated-string-initialization -x c -c /dev/null \
+		   -o /dev/null >/dev/null 2>&1
+WNUSI_FLAGS := $(shell $(WNUSI_TEST) && \
+		$(ECHO) '-Wno-unterminated-string-initialization')
+WORKAROUND_CFLAGS += $(WNUSI_FLAGS)
 endif
 
 # Some versions of gas choke on division operators, treating them as

--- a/src/drivers/infiniband/mlx_utils/src/public/mlx_pci_gw.c
+++ b/src/drivers/infiniband/mlx_utils/src/public/mlx_pci_gw.c
@@ -32,7 +32,7 @@ mlx_status
 mlx_pci_gw_check_capability_id(
 							IN mlx_utils *utils,
 							IN mlx_uint8 cap_pointer,
-							OUT mlx_boolean *bool
+							OUT mlx_boolean *result
 							)
 {
 	mlx_status 		status = MLX_SUCCESS;
@@ -41,7 +41,7 @@ mlx_pci_gw_check_capability_id(
 	status = mlx_pci_read(utils, MlxPciWidthUint8, offset,
 				1, &id);
 	MLX_CHECK_STATUS(utils, status, read_err,"failed to read capability id");
-	*bool = ( id == PCI_GW_CAPABILITY_ID );
+	*result = ( id == PCI_GW_CAPABILITY_ID );
 read_err:
 	return status;
 }

--- a/src/drivers/net/3c595.c
+++ b/src/drivers/net/3c595.c
@@ -443,7 +443,7 @@ vxsetlink(void)
     GO_WINDOW(1); 
 }
 
-static void t595_disable ( struct nic *nic ) {
+static void t595_disable ( struct nic *nic, void *hwdev __unused ) {
 
 	t595_reset(nic);
 

--- a/src/drivers/net/3c595.c
+++ b/src/drivers/net/3c595.c
@@ -342,8 +342,7 @@ eeprom_rdy()
  * before
  */
 static int
-get_e(offset)
-int offset;
+get_e(int offset)
 {
 	if (!eeprom_rdy())
 		return (0xffff);

--- a/src/drivers/net/amd8111e.c
+++ b/src/drivers/net/amd8111e.c
@@ -609,7 +609,7 @@ static int amd8111e_poll(struct nic *nic, int retrieve)
 	return pkt_ok;
 }
 
-static void amd8111e_disable(struct nic *nic)
+static void amd8111e_disable(struct nic *nic, void *hwdev __unused)
 {
 	struct amd8111e_priv *lp = nic->priv_data;
 

--- a/src/drivers/net/bnx2.c
+++ b/src/drivers/net/bnx2.c
@@ -2671,6 +2671,12 @@ err_out_disable:
 	return 0;
 }
 
+static void
+bnx2_remove(struct nic *nic, void *hwdev __unused)
+{
+	bnx2_disable(nic);
+}
+
 static struct pci_device_id bnx2_nics[] = {
 	PCI_ROM(0x14e4, 0x164a, "bnx2-5706",        "Broadcom NetXtreme II BCM5706", 0),
 	PCI_ROM(0x14e4, 0x164c, "bnx2-5708",        "Broadcom NetXtreme II BCM5708", 0),
@@ -2680,7 +2686,7 @@ static struct pci_device_id bnx2_nics[] = {
 
 PCI_DRIVER ( bnx2_driver, bnx2_nics, PCI_NO_CLASS );
 
-DRIVER ( "BNX2", nic_driver, pci_driver, bnx2_driver, bnx2_probe, bnx2_disable );
+DRIVER ( "BNX2", nic_driver, pci_driver, bnx2_driver, bnx2_probe, bnx2_remove );
 
 /*
 static struct pci_driver bnx2_driver __pci_driver = {

--- a/src/drivers/net/davicom.c
+++ b/src/drivers/net/davicom.c
@@ -159,7 +159,7 @@ static void davicom_reset(struct nic *nic);
 static void davicom_transmit(struct nic *nic, const char *d, unsigned int t,
 			   unsigned int s, const char *p);
 static int davicom_poll(struct nic *nic, int retrieve);
-static void davicom_disable(struct nic *nic);
+static void davicom_disable(struct nic *nic, void *hwdev);
 static void davicom_wait(unsigned int nticks);
 static int phy_read(int);
 static void phy_write(int, u16);
@@ -601,7 +601,7 @@ static int davicom_poll(struct nic *nic, int retrieve)
 /*********************************************************************/
 /* eth_disable - Disable the interface                               */
 /*********************************************************************/
-static void davicom_disable ( struct nic *nic ) {
+static void davicom_disable ( struct nic *nic, void *hwdev __unused ) {
 
   whereami("davicom_disable\n");
 

--- a/src/drivers/net/depca.c
+++ b/src/drivers/net/depca.c
@@ -644,7 +644,7 @@ static void depca_transmit(
 /**************************************************************************
 DISABLE - Turn off ethernet interface
 ***************************************************************************/
-static void depca_disable ( struct nic *nic ) {
+static void depca_disable ( struct nic *nic, void *hwdev __unused ) {
 	depca_reset(nic);
 
 	STOP_DEPCA(nic->ioaddr);

--- a/src/drivers/net/dmfe.c
+++ b/src/drivers/net/dmfe.c
@@ -435,7 +435,7 @@ static void dmfe_transmit(struct nic *nic,
 /**************************************************************************
 DISABLE - Turn off ethernet interface
 ***************************************************************************/
-static void dmfe_disable ( struct nic *nic __unused ) {
+static void dmfe_disable ( struct nic *nic __unused, void *hwdev __unused ) {
 	/* Reset & stop DM910X board */
 	outl(DM910X_RESET, BASE + DCR0);
 	udelay(5);

--- a/src/drivers/net/epic100.c
+++ b/src/drivers/net/epic100.c
@@ -51,7 +51,7 @@ struct epic_tx_desc {
 
 static void	epic100_open(void);
 static void	epic100_init_ring(void);
-static void	epic100_disable(struct nic *nic);
+static void	epic100_disable(struct nic *nic, void *hwdev);
 static int	epic100_poll(struct nic *nic, int retrieve);
 static void	epic100_transmit(struct nic *nic, const char *destaddr,
 				 unsigned int type, unsigned int len, const char *data);
@@ -419,7 +419,7 @@ epic100_poll(struct nic *nic, int retrieve)
 }
 
 
-static void epic100_disable ( struct nic *nic __unused ) {
+static void epic100_disable ( struct nic *nic __unused, void *hwdev __unused ) {
 	/* Soft reset the chip. */
 	outl(GC_SOFT_RESET, genctl);
 }

--- a/src/drivers/net/igbvf/igbvf_osdep.h
+++ b/src/drivers/net/igbvf/igbvf_osdep.h
@@ -35,8 +35,9 @@ FILE_LICENCE ( GPL2_ONLY );
 #ifndef _IGBVF_OSDEP_H_
 #define _IGBVF_OSDEP_H_
 
+#include <stdbool.h>
+
 #define u8         unsigned char
-#define bool       boolean_t
 #define dma_addr_t unsigned long
 #define __le16     uint16_t
 #define __le32     uint32_t
@@ -51,10 +52,6 @@ FILE_LICENCE ( GPL2_ONLY );
 #define ETH_FCS_LEN 4
 
 typedef int spinlock_t;
-typedef enum {
-    false = 0,
-    true = 1
-} boolean_t;
 
 #define usec_delay(x) udelay(x)
 #define msec_delay(x) mdelay(x)

--- a/src/drivers/net/ns8390.c
+++ b/src/drivers/net/ns8390.c
@@ -597,7 +597,7 @@ static int ns8390_poll(struct nic *nic, int retrieve)
 /**************************************************************************
 NS8390_DISABLE - Turn off adapter
 **************************************************************************/
-static void ns8390_disable ( struct nic *nic ) {
+static void ns8390_disable ( struct nic *nic, void *hwdev __unused ) {
 	ns8390_reset(nic);
 }
 

--- a/src/drivers/net/prism2_pci.c
+++ b/src/drivers/net/prism2_pci.c
@@ -44,7 +44,7 @@ static int prism2_pci_probe ( struct nic *nic, struct pci_device *pci ) {
   return prism2_probe ( nic, hw );
 }
 
-static void prism2_pci_disable ( struct nic *nic ) {
+static void prism2_pci_disable ( struct nic *nic, void *hwdev __unused ) {
   prism2_disable ( nic );
 }
 

--- a/src/drivers/net/prism2_plx.c
+++ b/src/drivers/net/prism2_plx.c
@@ -99,7 +99,7 @@ static int prism2_plx_probe ( struct nic *nic, struct pci_device *pci ) {
   return prism2_probe ( nic, hw );
 }
 
-static void prism2_plx_disable ( struct nic *nic ) {
+static void prism2_plx_disable ( struct nic *nic, void *hwdev __unused ) {
   prism2_disable ( nic );
 }
 

--- a/src/drivers/net/sis900.c
+++ b/src/drivers/net/sis900.c
@@ -164,7 +164,7 @@ static void sis900_transmit(struct nic *nic, const char *d,
                             unsigned int t, unsigned int s, const char *p);
 static int  sis900_poll(struct nic *nic, int retrieve);
 
-static void sis900_disable(struct nic *nic);
+static void sis900_disable(struct nic *nic, void *hwdev);
 
 static void sis900_irq(struct nic *nic, irq_action_t action);
 
@@ -1238,7 +1238,7 @@ sis900_poll(struct nic *nic, int retrieve)
  */
 
 static void
-sis900_disable ( struct nic *nic ) {
+sis900_disable ( struct nic *nic, void *hwdev __unused ) {
 
     sis900_init(nic);
 

--- a/src/drivers/net/sundance.c
+++ b/src/drivers/net/sundance.c
@@ -536,7 +536,7 @@ static void sundance_transmit(struct nic *nic, const char *d,	/* Destination */
 /**************************************************************************
 DISABLE - Turn off ethernet interface
 ***************************************************************************/
-static void sundance_disable ( struct nic *nic __unused ) {
+static void sundance_disable ( struct nic *nic __unused, void *hwdev __unused) {
 	/* put the card in its initial state */
 	/* This function serves 3 purposes.
 	 * This disables DMA and interrupts so we don't receive

--- a/src/drivers/net/tlan.c
+++ b/src/drivers/net/tlan.c
@@ -717,7 +717,7 @@ static void tlan_transmit(struct nic *nic, const char *d,	/* Destination */
 /**************************************************************************
 DISABLE - Turn off ethernet interface
 ***************************************************************************/
-static void tlan_disable ( struct nic *nic __unused ) {
+static void tlan_disable ( struct nic *nic __unused, void *hwdev __unused ) {
 	/* put the card in its initial state */
 	/* This function serves 3 purposes.
 	 * This disables DMA and interrupts so we don't receive

--- a/src/drivers/net/tulip.c
+++ b/src/drivers/net/tulip.c
@@ -494,7 +494,7 @@ static void tulip_reset(struct nic *nic);
 static void tulip_transmit(struct nic *nic, const char *d, unsigned int t,
                            unsigned int s, const char *p);
 static int tulip_poll(struct nic *nic, int retrieve);
-static void tulip_disable(struct nic *nic);
+static void tulip_disable(struct nic *nic, void *hwdev);
 static void nway_start(struct nic *nic);
 static void pnic_do_nway(struct nic *nic);
 static void select_media(struct nic *nic, int startup);
@@ -1128,7 +1128,7 @@ static int tulip_poll(struct nic *nic, int retrieve)
 /*********************************************************************/
 /* eth_disable - Disable the interface                               */
 /*********************************************************************/
-static void tulip_disable ( struct nic *nic ) {
+static void tulip_disable ( struct nic *nic, void *hwdev __unused ) {
 
     whereami("tulip_disable\n");
 

--- a/src/drivers/net/w89c840.c
+++ b/src/drivers/net/w89c840.c
@@ -579,7 +579,7 @@ static void w89c840_transmit(
 /**************************************************************************
 w89c840_disable - Turn off ethernet interface
 ***************************************************************************/
-static void w89c840_disable ( struct nic *nic ) {
+static void w89c840_disable ( struct nic *nic, void *hwdev __unused ) {
 
     w89c840_reset(nic);
 

--- a/src/include/ipxe/efi/ProcessorBind.h
+++ b/src/include/ipxe/efi/ProcessorBind.h
@@ -10,20 +10,54 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  *  - mcb30
  */
 
-#if __i386__
+#ifdef EFI_HOSTONLY
+
+/*
+ * We cannot rely on the EDK2 ProcessorBind.h headers when compiling a
+ * binary for execution on the build host itself, since the host's CPU
+ * architecture may not even be supported by EDK2.
+ */
+
+/* Define the basic integer types in terms of the host's <stdint.h> */
+#include <stdint.h>
+typedef int8_t INT8;
+typedef int16_t INT16;
+typedef int32_t INT32;
+typedef int64_t INT64;
+typedef uint8_t UINT8;
+typedef long INTN;
+typedef uint16_t UINT16;
+typedef uint32_t UINT32;
+typedef uint64_t UINT64;
+typedef unsigned long UINTN;
+typedef int8_t CHAR8;
+typedef int16_t CHAR16;
+typedef uint8_t BOOLEAN;
+
+/* Define EFIAPI as whatever API the host uses by default */
+#define EFIAPI
+
+/* Define an architecture-neutral MDE_CPU macro to prevent build errors */
+#define MDE_CPU_EBC
+
+#else /* EFI_HOSTONLY */
+
+#ifdef __i386__
 #include <ipxe/efi/Ia32/ProcessorBind.h>
 #endif
 
-#if __x86_64__
+#ifdef __x86_64__
 #include <ipxe/efi/X64/ProcessorBind.h>
 #endif
 
-#if __arm__
+#ifdef __arm__
 #include <ipxe/efi/Arm/ProcessorBind.h>
 #endif
 
-#if __aarch64__
+#ifdef __aarch64__
 #include <ipxe/efi/AArch64/ProcessorBind.h>
 #endif
+
+#endif /* EFI_HOSTONLY */
 
 #endif /* _IPXE_EFI_PROCESSOR_BIND_H */

--- a/src/include/ipxe/xenver.h
+++ b/src/include/ipxe/xenver.h
@@ -1,5 +1,5 @@
 #ifndef _IPXE_XENVER_H
-#define _IPXE_VENVER_H
+#define _IPXE_XENVER_H
 
 /** @file
  *

--- a/src/include/nic.h
+++ b/src/include/nic.h
@@ -217,8 +217,7 @@ static inline void * legacy_isa_get_drvdata ( void *hwdev ) {
 	}								  \
 	static inline void						  \
 	_name ## _disable ( struct nic *nic, void *hwdev ) {		  \
-		void ( * _unsafe_disable ) () = _disable;		  \
-		_unsafe_disable ( nic, hwdev );				  \
+		_disable ( nic, hwdev );				  \
 	}								  \
 	static inline int						  \
 	_name ## _pci_legacy_probe ( struct pci_device *pci ) {		  \

--- a/src/interface/efi/efi_hii.c
+++ b/src/interface/efi/efi_hii.c
@@ -147,13 +147,13 @@ void efi_ifr_end_op ( struct efi_ifr_builder *ifr ) {
  */
 void efi_ifr_false_op ( struct efi_ifr_builder *ifr ) {
 	size_t dispaddr = ifr->ops_len;
-	EFI_IFR_FALSE *false;
+	EFI_IFR_FALSE *op;
 
 	/* Add opcode */
-	false = efi_ifr_op ( ifr, EFI_IFR_FALSE_OP, sizeof ( *false ) );
+	op = efi_ifr_op ( ifr, EFI_IFR_FALSE_OP, sizeof ( *op ) );
 
 	DBGC ( ifr, "IFR %p false\n", ifr );
-	DBGC2_HDA ( ifr, dispaddr, false, sizeof ( *false ) );
+	DBGC2_HDA ( ifr, dispaddr, op, sizeof ( *op ) );
 }
 
 /**
@@ -462,13 +462,13 @@ void efi_ifr_text_op ( struct efi_ifr_builder *ifr, unsigned int prompt_id,
  */
 void efi_ifr_true_op ( struct efi_ifr_builder *ifr ) {
 	size_t dispaddr = ifr->ops_len;
-	EFI_IFR_TRUE *true;
+	EFI_IFR_TRUE *op;
 
 	/* Add opcode */
-	true = efi_ifr_op ( ifr, EFI_IFR_TRUE_OP, sizeof ( *true ) );
+	op = efi_ifr_op ( ifr, EFI_IFR_TRUE_OP, sizeof ( *op ) );
 
 	DBGC ( ifr, "IFR %p true\n", ifr );
-	DBGC2_HDA ( ifr, dispaddr, true, sizeof ( *true ) );
+	DBGC2_HDA ( ifr, dispaddr, op, sizeof ( *op ) );
 }
 
 /**

--- a/src/util/elf2efi.c
+++ b/src/util/elf2efi.c
@@ -33,6 +33,8 @@
 #include <fcntl.h>
 #include <elf.h>
 #include <libgen.h>
+
+#define EFI_HOSTONLY
 #include <ipxe/efi/Uefi.h>
 #include <ipxe/efi/IndustryStandard/PeImage.h>
 


### PR DESCRIPTION
We cannot rely on the EDK2 ProcessorBind.h headers when compiling a
binary for execution on the build host itself (e.g. elf2efi), since
the host's CPU architecture may not even be supported by EDK2.

Fix by skipping ProcessorBind.h when building a host binary, and
defining the bare minimum required to allow other EDK2 headers to
compile cleanly.

Reported-by: Michal Suchánek <msuchanek@suse.de>
Signed-off-by: Michael Brown <mcb30@ipxe.org>
(cherry picked from commit a99e435c8e24887ce80c322029ba23103e00d1c2)
